### PR TITLE
Add Battery1 interface access

### DIFF
--- a/include/simplebluez/Device.h
+++ b/include/simplebluez/Device.h
@@ -4,6 +4,7 @@
 
 #include <simplebluez/Characteristic.h>
 #include <simplebluez/Service.h>
+#include <simplebluez/interfaces/Battery1.h>
 #include <simplebluez/interfaces/Device1.h>
 
 namespace SimpleBluez {

--- a/include/simplebluez/Device.h
+++ b/include/simplebluez/Device.h
@@ -40,11 +40,18 @@ class Device : public SimpleDBus::Proxy {
     void set_on_disconnected(std::function<void()> callback);
     void clear_on_disconnected();
 
+    // ----- BATTERY INTERFACE -----
+    bool has_battery_interface();
+    uint8_t read_battery_percentage();
+    void set_on_battery_percentage_changed(std::function<void(uint8_t new_value)> callback);
+    void clear_on_battery_percentage_changed();
+
   private:
     std::shared_ptr<SimpleDBus::Proxy> path_create(const std::string& path) override;
     std::shared_ptr<SimpleDBus::Interface> interfaces_create(const std::string& interface_name) override;
 
     std::shared_ptr<Device1> device1();
+    std::shared_ptr<Battery1> battery1();
 };
 
 }  // namespace SimpleBluez

--- a/include/simplebluez/interfaces/Battery1.h
+++ b/include/simplebluez/interfaces/Battery1.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <simpledbus/advanced/Interface.h>
+
+#include <string>
+
+namespace SimpleBluez {
+
+class Battery1 : public SimpleDBus::Interface {
+  public:
+    Battery1(std::shared_ptr<SimpleDBus::Connection> conn, std::string path);
+    virtual ~Battery1() = default;
+
+    // ----- METHODS -----
+
+    // ----- PROPERTIES -----
+    uint8_t Percentage();
+
+  protected:
+    void property_changed(std::string option_name) override;
+};
+
+}  // namespace SimpleBluez

--- a/include/simplebluez/interfaces/Battery1.h
+++ b/include/simplebluez/interfaces/Battery1.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <simpledbus/advanced/Callback.h>
 #include <simpledbus/advanced/Interface.h>
 
 #include <string>
@@ -9,12 +10,15 @@ namespace SimpleBluez {
 class Battery1 : public SimpleDBus::Interface {
   public:
     Battery1(std::shared_ptr<SimpleDBus::Connection> conn, std::string path);
-    virtual ~Battery1() = default;
+    virtual ~Battery1();
 
     // ----- METHODS -----
 
     // ----- PROPERTIES -----
     uint8_t Percentage();
+
+    // ----- CALLBACKS -----
+    SimpleDBus::Callback<std::function<void()>> OnPercentageChanged;
 
   protected:
     void property_changed(std::string option_name) override;

--- a/src/Device.cpp
+++ b/src/Device.cpp
@@ -18,6 +18,9 @@ std::shared_ptr<SimpleDBus::Interface> Device::interfaces_create(const std::stri
     if (interface_name == "org.bluez.Device1") {
         return std::static_pointer_cast<SimpleDBus::Interface>(std::make_shared<Device1>(_conn, _path));
     }
+    else if (interface_name == "org.bluez.Battery1") {
+        return std::static_pointer_cast<SimpleDBus::Interface>(std::make_shared<Battery1>(_conn, _path));
+    }
 
     auto interface = std::make_shared<SimpleDBus::Interface>(_conn, _bus_name, _path, interface_name);
     return std::static_pointer_cast<SimpleDBus::Interface>(interface);

--- a/src/interfaces/Battery1.cpp
+++ b/src/interfaces/Battery1.cpp
@@ -19,8 +19,5 @@ uint8_t Battery1::Percentage() {
 void Battery1::property_changed(std::string option_name) {
     if (option_name == "Percentage") {
         OnPercentageChanged();
-        std::cout << "Battery1: Percentage property_changed: "
-                  << int(_properties["Percentage"].get_byte())
-                  << std::endl;
     }
 }

--- a/src/interfaces/Battery1.cpp
+++ b/src/interfaces/Battery1.cpp
@@ -1,0 +1,21 @@
+#include "simplebluez/interfaces/Battery1.h"
+
+#include <iostream>
+
+using namespace SimpleBluez;
+
+Battery1::Battery1(std::shared_ptr<SimpleDBus::Connection> conn, std::string path)
+    : SimpleDBus::Interface(conn, "org.bluez", path, "org.bluez.Battery1") {}
+
+uint8_t Battery1::Percentage() {
+    std::scoped_lock lock(_property_update_mutex);
+    return _properties["Percentage"].get_byte();
+}
+
+void Battery1::property_changed(std::string option_name) {
+    if (option_name == "Percentage") {
+        std::cout << "Battery1: Percentage property_changed: "
+                  << int(_properties["Percentage"].get_byte())
+                  << std::endl;
+    }
+}

--- a/src/interfaces/Battery1.cpp
+++ b/src/interfaces/Battery1.cpp
@@ -7,6 +7,10 @@ using namespace SimpleBluez;
 Battery1::Battery1(std::shared_ptr<SimpleDBus::Connection> conn, std::string path)
     : SimpleDBus::Interface(conn, "org.bluez", path, "org.bluez.Battery1") {}
 
+Battery1::~Battery1() {
+    OnPercentageChanged.unload();
+}
+
 uint8_t Battery1::Percentage() {
     std::scoped_lock lock(_property_update_mutex);
     return _properties["Percentage"].get_byte();
@@ -14,6 +18,7 @@ uint8_t Battery1::Percentage() {
 
 void Battery1::property_changed(std::string option_name) {
     if (option_name == "Percentage") {
+        OnPercentageChanged();
         std::cout << "Battery1: Percentage property_changed: "
                   << int(_properties["Percentage"].get_byte())
                   << std::endl;


### PR DESCRIPTION
The Battery1 interface was added in Bluez version 5.48. If the Bluez battery plugin is active (active by default on Ubuntu 20.04 at least), it replaces the battery service (UUID 0x180f) by the Battery1 interface.

This PR adds code for accessing the interface via `Device`. For more information, see [PR in SimpleBLE](https://github.com/OpenBluetoothToolbox/SimpleBLE/pull/47).