### PR TITLE
Initial attempt to set up build process to be usable through conan

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,11 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/find")
 
 project(SimpleBluez VERSION 0.1 LANGUAGES CXX)
 
+if (CONAN_BUILD)
+    include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+    conan_basic_setup()
+endif()
+
 option(LIBFMT_VENDORIZE "Enable vendorized libfmt" ON)
 option(SIMPLEDBUS_VENDORIZE "Enable vendorized SimpleDBus" ON)
 
@@ -64,6 +69,10 @@ target_link_libraries(simplebluez PUBLIC simpledbus-static pthread ${EXTRA_LINK_
 
 target_link_libraries(simplebluez-static PRIVATE fmt::fmt-header-only)
 target_link_libraries(simplebluez PRIVATE fmt::fmt-header-only)
+
+if (CONAN_BUILD)
+    add_subdirectory(examples)
+endif()
 
 # Export the variables needed by the parent project
 if(NOT ${STANDALONE})

--- a/conanfile.py
+++ b/conanfile.py
@@ -1,0 +1,49 @@
+from conans import ConanFile, CMake, tools
+from conans.errors import ConanException
+import os
+
+class SimpleBlueZ(ConanFile):
+   name = "simplebluez"
+   license = "MIT"
+   description = "A simple C++ wrapper around Bluez with a commercially-friendly licence"
+   settings = "os", "compiler", "build_type", "arch"
+   requires = "simpledbus/2.1.1"
+   options = {
+      "log_level": ["VERBOSE_3","VERBOSE_2","VERBOSE_1","VERBOSE_0","DEBUG","INFO","WARNING","ERROR","FATAL"],
+      "shared": [True, False]
+   }
+   default_options = {
+      "fmt:header_only" : True,
+      "log_level" : "FATAL"
+   }
+   generators = ["cmake_find_package","cmake"]
+   
+   exports_sources = "CMakeLists.txt", "include/*",  "src/*",  "examples/*"
+
+   def build(self):
+      cmake = CMake(self)
+      cmake.definitions["SIMPLEBLUEZ_LOG_LEVEL"] = self.options.log_level
+      cmake.definitions["CONAN_BUILD"] = True
+      cmake.configure()
+      cmake.build()
+
+   def package(self):
+        self.copy("*.h", dst="include", src="include")
+        if self.options.shared == True:
+           self.copy("*.so", dst="lib", keep_path=False)
+        else:
+           self.copy("*.a", dst="lib", keep_path=False)
+        self.copy("*", dst="bin", src="examples/list_adapters/bin", keep_path=False)
+        self.copy("*", dst="bin", src="examples/list_paired/bin", keep_path=False)
+        self.copy("*", dst="bin", src="examples/scan/bin", keep_path=False)
+        self.copy("*", dst="bin", src="examples/connect/bin", keep_path=False)
+        self.copy("*", dst="bin", src="examples/pair/bin", keep_path=False)
+        self.copy("*", dst="bin", src="examples/read/bin", keep_path=False)
+        self.copy("*", dst="bin", src="examples/notify/bin", keep_path=False)
+        self.copy("*", dst="bin", src="examples/ble_nus/bin", keep_path=False)
+
+   def package_info(self):
+      self.cpp_info.libs = tools.collect_libs(self)
+   
+   def deploy(self):
+      self.copy("*", dst="bin", src="bin")

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -12,10 +12,12 @@ file(WRITE ${CMAKE_BINARY_DIR}/.gitignore "*")
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
-# Include simplebluez
-# Build artifacts in a separate folder
-add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/.. ${CMAKE_BINARY_DIR}/simplebluez)
-include_directories(${SIMPLEBLUEZ_INCLUDES})
+if (NOT CONAN_BUILD)
+    # Include simplebluez
+    # Build artifacts in a separate folder
+    add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/.. ${CMAKE_BINARY_DIR}/simplebluez)
+    include_directories(${SIMPLEBLUEZ_INCLUDES})
+endif()
 
 add_subdirectory(list_adapters)
 add_subdirectory(list_paired)

--- a/examples/ble_nus/CMakeLists.txt
+++ b/examples/ble_nus/CMakeLists.txt
@@ -2,6 +2,11 @@ cmake_minimum_required(VERSION 3.16.0)
 
 project(EXAMPLE_BLE_NUS)
 
+if (CONAN_BUILD)
+    include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+    conan_basic_setup()
+endif()
+
 message("-- [INFO] Building Example")
 add_executable(example_ble_nus ble_nus.cpp)
-target_link_libraries(example_ble_nus simplebluez-static)
+target_link_libraries(example_ble_nus simplebluez-static ${CONAN_LIBS})

--- a/examples/connect/CMakeLists.txt
+++ b/examples/connect/CMakeLists.txt
@@ -2,6 +2,11 @@ cmake_minimum_required(VERSION 3.16.0)
 
 project(EXAMPLE_CONNECT)
 
+if (CONAN_BUILD)
+    include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+    conan_basic_setup()
+endif()
+
 message("-- [INFO] Building Example")
 add_executable(example_connect connect.cpp)
-target_link_libraries(example_connect simplebluez-static)
+target_link_libraries(example_connect simplebluez-static ${CONAN_LIBS})

--- a/examples/list_adapters/CMakeLists.txt
+++ b/examples/list_adapters/CMakeLists.txt
@@ -2,6 +2,11 @@ cmake_minimum_required(VERSION 3.16.0)
 
 project(EXAMPLE_LIST_ADAPTERS)
 
+if (CONAN_BUILD)
+    include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+    conan_basic_setup()
+endif()
+
 message("-- [INFO] Building Example")
 add_executable(example_list_adapters list_adapters.cpp)
-target_link_libraries(example_list_adapters simplebluez-static)
+target_link_libraries(example_list_adapters simplebluez-static ${CONAN_LIBS})

--- a/examples/list_paired/CMakeLists.txt
+++ b/examples/list_paired/CMakeLists.txt
@@ -2,6 +2,11 @@ cmake_minimum_required(VERSION 3.16.0)
 
 project(EXAMPLE_LIST_PAIRED)
 
+if (CONAN_BUILD)
+    include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+    conan_basic_setup()
+endif()
+
 message("-- [INFO] Building Example")
 add_executable(example_list_paired list_paired.cpp)
-target_link_libraries(example_list_paired simplebluez-static)
+target_link_libraries(example_list_paired simplebluez-static ${CONAN_LIBS})

--- a/examples/notify/CMakeLists.txt
+++ b/examples/notify/CMakeLists.txt
@@ -2,6 +2,11 @@ cmake_minimum_required(VERSION 3.16.0)
 
 project(EXAMPLE_NOTIFY)
 
+if (CONAN_BUILD)
+    include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+    conan_basic_setup()
+endif()
+
 message("-- [INFO] Building Example")
 add_executable(example_notify notify.cpp)
-target_link_libraries(example_notify simplebluez-static)
+target_link_libraries(example_notify simplebluez-static ${CONAN_LIBS})

--- a/examples/pair/CMakeLists.txt
+++ b/examples/pair/CMakeLists.txt
@@ -2,6 +2,11 @@ cmake_minimum_required(VERSION 3.16.0)
 
 project(EXAMPLE_PAIR)
 
+if (CONAN_BUILD)
+    include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+    conan_basic_setup()
+endif()
+
 message("-- [INFO] Building Example")
 add_executable(example_pair pair.cpp)
-target_link_libraries(example_pair simplebluez-static)
+target_link_libraries(example_pair simplebluez-static ${CONAN_LIBS})

--- a/examples/read/CMakeLists.txt
+++ b/examples/read/CMakeLists.txt
@@ -2,6 +2,11 @@ cmake_minimum_required(VERSION 3.16.0)
 
 project(EXAMPLE_READ)
 
+if (CONAN_BUILD)
+    include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+    conan_basic_setup()
+endif()
+
 message("-- [INFO] Building Example")
 add_executable(example_read read.cpp)
-target_link_libraries(example_read simplebluez-static)
+target_link_libraries(example_read simplebluez-static ${CONAN_LIBS})

--- a/examples/scan/CMakeLists.txt
+++ b/examples/scan/CMakeLists.txt
@@ -2,6 +2,11 @@ cmake_minimum_required(VERSION 3.16.0)
 
 project(EXAMPLE_SCAN)
 
+if (CONAN_BUILD)
+    include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+    conan_basic_setup()
+endif()
+
 message("-- [INFO] Building Example")
 add_executable(example_scan scan.cpp)
-target_link_libraries(example_scan simplebluez-static)
+target_link_libraries(example_scan simplebluez-static ${CONAN_LIBS})

--- a/include/simplebluez/Logging.h
+++ b/include/simplebluez/Logging.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <cstdint>
 #include <string>
 

--- a/src/Exceptions.cpp
+++ b/src/Exceptions.cpp
@@ -1,6 +1,6 @@
 #include <simplebluez/Exceptions.h>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 namespace SimpleBluez {
 


### PR DESCRIPTION
Hello! This will be similar to https://github.com/OpenBluetoothToolbox/SimpleDBus/pull/24 which I opened for SimpleDBus.  have done an initial attempt at making this library usable with a conan build and packaging. My goals were to change as little as possible in the build process so that it could continue to be built as is if desired.

In order to build via conan I am generally using docker images. In this case I used images conanio/gcc8-armv7hf and conanio/gcc10 to test. If you create a docker image using these and have access to the source you can run a command like this to build the library and create the conan package. I use VS Code which has some good support for running your code inside docker images.

`conan create . simplebluez/0.4.1@ -s compiler.libcxx=libstdc++11 -o shared=False -o simpledbus:shared=False`

The version number is arbitrary based on whatever version you are packaging but I chose the next version for this example. You will also notice a couple things different from the other request:

- I did not use the "build=missing" argument here since it was run where the dependencies had already been set up.  If that arg was used it could be run on a fresh setup.
- The version for simpledbus is listed as 2.1.1 as that is the version I used to build the other library.
- You will see here that I specified the non-shared version of the simpledbus library to be used.  It currently won't work when using the shared version because other things in the build specifically link to simpledbus-static.  If a true separation is done then the build should be able to use whichever version the user decides to use for their build.  See the first note below as more explanation.

A few notes on general setup with Conan and what I did:

- In the existing build both the static and shared library versions are built at once. Conan generally uses this as a setting so that users of a package pick by option used rather than by specifying the library type in the build. For this I have not changed the compilation but only the packaging so that only the appropriate library goes based on the option used (like False in the example above). Ideally in the longer term the compilation would be set up to only build one with the library type defined by the option.
- I changed the build for conan so that the examples are always included. For now I also included them in the package so that they can be used by a "conan deploy" operation. This lets people try out the example executables without having to build if they have the appropriate setup.
- I did not do anything with tests. Conan has the ability to include this but it looked like a bit much for now.

I changed the includes for the fmt library to include format.h instead of core.h. I believe this is the correct method and when I tried to use it without the examples were not linking because the library was including references to fmt symbols that were not already compiled in.

Please check it out and let me know if you have any questions or problems with it. Conan is a great system and it will allow you to really get dependencies set up correctly if you use the versioning as it was intended so that a version of something clearly knows what the versions of the dependencies are.  Also if you use a repository to keep the packages you can keep the binaries around for frequently used items so they don't need to be rebuilt every time.   